### PR TITLE
security: Stop returning the exception details to the API users

### DIFF
--- a/spark_on_k8s/api/__init__.py
+++ b/spark_on_k8s/api/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from httpx import AsyncClient
@@ -9,6 +10,8 @@ from spark_on_k8s.utils.configuration import Configuration
 
 if TYPE_CHECKING:
     from kubernetes_asyncio.client import ApiClient
+
+logger = logging.getLogger("spark_on_k8s.api")
 
 
 class KubernetesClientSingleton:

--- a/spark_on_k8s/api/app.py
+++ b/spark_on_k8s/api/app.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from fastapi import APIRouter, Response
 
 from spark_on_k8s.api import KubernetesClientSingleton
+from spark_on_k8s.api.utils import handle_exception
 from spark_on_k8s.utils.async_app_manager import AsyncSparkAppManager
 
 router = APIRouter(
@@ -28,7 +29,7 @@ async def kill_app(namespace: str, app_id: str):
         return Response(status_code=200)
     except Exception as e:
         # TODO: handle exceptions properly and return proper status code
-        return Response(status_code=500, content=str(e))
+        return handle_exception(e, 500)
 
 
 @router.delete(
@@ -49,4 +50,4 @@ async def delete_app(namespace: str, app_id: str, force: bool = False):
         return Response(status_code=200)
     except Exception as e:
         # TODO: handle exceptions properly and return proper status code
-        return Response(status_code=500, content=str(e))
+        return handle_exception(e, 500)

--- a/spark_on_k8s/api/utils.py
+++ b/spark_on_k8s/api/utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import uuid
+
+from starlette.responses import Response
+
+
+def handle_exception(e: Exception, status_code: int = 500) -> Response:
+    from spark_on_k8s.api import logger
+
+    exception_uuid = uuid.uuid4()
+    logger.exception("Exception %s: %s", exception_uuid, e)
+    return Response(
+        status_code=status_code,
+        content=(
+            f"The query failed with exception {exception_uuid},"
+            f" please contact the administrator for more information."
+        ),
+    )

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+
+def test_handle_exception(caplog):
+    from spark_on_k8s.api.utils import handle_exception
+
+    e = Exception("test exception")
+    response = handle_exception(e, status_code=500)
+    assert len(caplog.messages) == 1
+    exception_uuid = caplog.messages[0].split()[1][:-1]
+    assert response.status_code == 500
+    assert response.body == (
+        b"The query failed with exception "
+        + exception_uuid.encode()
+        + b", please contact the administrator for more information."
+    )


### PR DESCRIPTION
Instead of returning the exception message and details in case of an error in the API query processing, we can generate a unique UUID to the exception and log it with ID, then return the ID to the API user, in this case, only the API admin can check the log to help the user understand the problem.