### PR TITLE
fix: propagate service account + test

### DIFF
--- a/spark_on_k8s/client.py
+++ b/spark_on_k8s/client.py
@@ -371,6 +371,7 @@ class SparkOnK8S(LoggingMixin):
             image=image,
             image_pull_policy=image_pull_policy,
             namespace=namespace,
+            service_account=service_account,
             args=driver_command_args,
             extra_labels={**extra_labels, **driver_labels},
             annotations=driver_annotations,

--- a/tests/test_spark_client.py
+++ b/tests/test_spark_client.py
@@ -198,6 +198,7 @@ class TestSparkOnK8s:
         assert created_pod.metadata.labels["spark-app-id"] == expected_app_id
         assert created_pod.metadata.labels["spark-role"] == "driver"
         assert created_pod.spec.containers[0].image == "pyspark-job"
+        assert created_pod.spec.service_account_name == "spark"
         assert created_pod.spec.containers[0].args == [
             "driver",
             "--master",
@@ -296,6 +297,7 @@ class TestSparkOnK8s:
 
         created_pod = mock_create_namespaced_pod.call_args[1]["body"]
         assert created_pod.spec.containers[0].image == "test-spark-on-k8s-docker-image"
+        assert created_pod.spec.service_account_name == "test-service-account"
         assert created_pod.spec.containers[0].args == [
             "driver",
             "--master",


### PR DESCRIPTION
Using this library I've noticed that `service_account` argument in `submit_app` was not propagated in `SparkAppManager.create_spark_pod_spec` and so the spark driver was correctly created with `"spark.kubernetes.authenticate.driver.serviceAccountName": service_account` but then the pod was using the default `spark` service account, leading to an error.

Also, improved a bit two tests to certify that the service account was correctly set. 

This PR should be fine to fix the issue, but if something is missing please tell me and I will try to complete it.

Thank you
