### PR TITLE
fix(airflow): load namespace and pod_name from trigger event

### DIFF
--- a/spark_on_k8s/airflow/operators.py
+++ b/spark_on_k8s/airflow/operators.py
@@ -407,6 +407,8 @@ class SparkOnK8SOperator(BaseOperator):
         raise AirflowException(f"The job finished with status: {app_status}")
 
     def execute_complete(self, context: Context, event: dict, **kwargs):
+        self.namespace = event["namespace"]
+        self._driver_pod_name = event["pod_name"]
         if self.app_waiter == "log":
             from spark_on_k8s.utils.app_manager import SparkAppManager
 


### PR DESCRIPTION
Otherwise https://github.com/hussein-awala/spark-on-k8s/blob/310aac5a0f4a39661ac1c5e316d6225785b9c0c0/spark_on_k8s/airflow/operators.py#L425 will fail if `spark_on_k8s_service_url` is `True`