### PR TITLE
fix(python-client): truncate driver pod name and fix app name/id truncation

### DIFF
--- a/spark_on_k8s/client.py
+++ b/spark_on_k8s/client.py
@@ -313,7 +313,7 @@ class SparkOnK8S(LoggingMixin):
             "spark.kubernetes.container.image": image,
             "spark.driver.host": app_id,
             "spark.driver.port": "7077",
-            "spark.kubernetes.driver.pod.name": f"{app_id}-driver",
+            "spark.kubernetes.driver.pod.name": SparkAppManager._get_pod_name(app_id=app_id),
             "spark.kubernetes.executor.podNamePrefix": app_id,
             "spark.kubernetes.container.image.pullPolicy": image_pull_policy,
             "spark.driver.memory": f"{driver_resources.memory}m",
@@ -522,8 +522,9 @@ class SparkOnK8S(LoggingMixin):
             # All to lowercase
             app_name = app_name.lower()
             app_id_suffix_str = app_id_suffix()
-            if len(app_name) > (63 - len(app_id_suffix_str) + 1):
-                app_name = app_name[: (63 - len(app_id_suffix_str)) + 1]
+            # Maximum length for pod labels and service names is 63 characters
+            if len(app_name) > (63 - len(app_id_suffix_str)):
+                app_name = app_name[: (63 - len(app_id_suffix_str))]
             # Replace all non-alphanumeric characters with dashes
             app_name = re.sub(r"[^0-9a-zA-Z]+", "-", app_name)
             # Remove leading non-alphabetic characters

--- a/spark_on_k8s/utils/warnings.py
+++ b/spark_on_k8s/utils/warnings.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import warnings
+
+
+class WarningCache:
+    _warning_ids = set()
+
+    @classmethod
+    def warn(
+        cls, *, warning_id: str, message: str, category: type[Warning] = UserWarning, stacklevel: int = 1
+    ):
+        if warning_id not in cls._warning_ids:
+            cls._warning_ids.add(warning_id)
+            warnings.warn(message=message, category=category, stacklevel=stacklevel)
+
+
+class LongAppNameWarning(UserWarning):
+    pass


### PR DESCRIPTION
closes: #115

This PR:
- fixes a bug in app_name truncation, where the maximum allowed length for labels is 63, not 64.
- truncates driver pod name in case app_id + `-driver` suffix exceeds 63 characters

According to my tests, the executor pods created by the driver pod are fine, and there is no need to truncate their names.

We may remove the "-driver" suffix in future releases as it is not needed, but we need to make its removal optional until the stable version is released.