### PR TITLE
feat: auto handle pod template with configmap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ packages = [{include = "spark_on_k8s"}]
 python = "^3.9"
 kubernetes = ">=26.1.0"
 click = "^8.0.1"
+pyyaml = "^6.0"
 fastapi = {version = "^0.109.1", optional = true}
 kubernetes-asyncio = {version = ">=26.9.0", optional = true}
 uvicorn = {version = "^0.26.0", optional = true}

--- a/spark_on_k8s/cli/app.py
+++ b/spark_on_k8s/cli/app.py
@@ -28,6 +28,7 @@ from spark_on_k8s.cli.options import (
     executor_min_instances_option,
     executor_node_selector_option,
     executor_pod_template_path_option,
+    executor_template_option,
     force_option,
     image_pull_policy_option,
     logs_option,
@@ -137,6 +138,7 @@ def wait(app_id: str, namespace: str):
         driver_annotations_option,
         executor_annotations_option,
         executor_pod_template_path_option,
+        executor_template_option,
     ],
     help="Submit a Spark application.",
 )
@@ -175,6 +177,7 @@ def submit(
     driver_annotations: dict[str, str],
     executor_annotations: dict[str, str],
     executor_pod_template_path: str,
+    executor_template: str,
 ):
     from spark_on_k8s.client import ExecutorInstances, PodResources, SparkOnK8S
 
@@ -219,4 +222,5 @@ def submit(
         driver_annotations=driver_annotations,
         executor_annotations=executor_annotations,
         executor_pod_template_path=executor_pod_template_path,
+        executor_template=executor_template,
     )

--- a/spark_on_k8s/cli/app.py
+++ b/spark_on_k8s/cli/app.py
@@ -177,7 +177,7 @@ def submit(
     driver_annotations: dict[str, str],
     executor_annotations: dict[str, str],
     executor_pod_template_path: str,
-    executor_template: str,
+    executor_pod_template: str,
 ):
     from spark_on_k8s.client import ExecutorInstances, PodResources, SparkOnK8S
 
@@ -222,5 +222,5 @@ def submit(
         driver_annotations=driver_annotations,
         executor_annotations=executor_annotations,
         executor_pod_template_path=executor_pod_template_path,
-        executor_template=executor_template,
+        executor_template=executor_pod_template,
     )

--- a/spark_on_k8s/cli/options.py
+++ b/spark_on_k8s/cli/options.py
@@ -306,6 +306,6 @@ executor_template_option = click.Option(
     ("--executor-template", "executor_template"),
     type=str,
     default=Configuration.SPARK_ON_K8S_EXECUTOR_TEMPLATE,
-    show_default=True,
+    show_default=False,
     help="Executor pod template content as string or local file path.",
 )

--- a/spark_on_k8s/cli/options.py
+++ b/spark_on_k8s/cli/options.py
@@ -302,3 +302,10 @@ executor_pod_template_path_option = click.Option(
     show_default=True,
     help="The path to the executor pod template file.",
 )
+executor_template_option = click.Option(
+    ("--executor-template", "executor_template"),
+    type=str,
+    default=Configuration.SPARK_ON_K8S_EXECUTOR_TEMPLATE,
+    show_default=True,
+    help="Executor pod template content as string or local file path.",
+)

--- a/spark_on_k8s/client.py
+++ b/spark_on_k8s/client.py
@@ -184,7 +184,7 @@ class SparkOnK8S(LoggingMixin):
         executor_labels: dict[str, str] | ArgNotSet = NOTSET,
         driver_tolerations: list[k8s.V1Toleration] | ArgNotSet = NOTSET,
         executor_pod_template_path: str | ArgNotSet = NOTSET,
-        executor_template: str | ArgNotSet = NOTSET,
+        executor_pod_template: str | ArgNotSet = NOTSET,
         startup_timeout: int | ArgNotSet = NOTSET,
         driver_init_containers: list[k8s.V1Container] | ArgNotSet = NOTSET,
         driver_host_aliases: list[k8s.V1HostAlias] | ArgNotSet = NOTSET,
@@ -230,7 +230,7 @@ class SparkOnK8S(LoggingMixin):
             executor_node_selector: Node selector for the executors
             driver_tolerations: List of tolerations for the driver
             executor_pod_template_path: Path to the executor pod template file
-            executor_template: Executor pod template content as string or local file path. If provided,
+            executor_pod_template: Executor pod template content as string or local file path. If provided,
                 a ConfigMap will be created and mounted automatically
             startup_timeout: Timeout in seconds to wait for the application to start
             driver_init_containers: List of init containers to run before the driver starts
@@ -340,8 +340,9 @@ class SparkOnK8S(LoggingMixin):
             driver_tolerations = []
         if executor_pod_template_path is NOTSET or executor_pod_template_path is None:
             executor_pod_template_path = Configuration.SPARK_ON_K8S_EXECUTOR_POD_TEMPLATE_PATH
-        if executor_template is NOTSET or executor_template is None:
-            executor_template = Configuration.SPARK_ON_K8S_EXECUTOR_TEMPLATE
+        if executor_pod_template is NOTSET or executor_pod_template is None:
+            
+            executor_pod_template = Configuration.SPARK_ON_K8S_EXECUTOR_TEMPLATE
         if startup_timeout is NOTSET:
             startup_timeout = Configuration.SPARK_ON_K8S_STARTUP_TIMEOUT
         if driver_init_containers is NOTSET:
@@ -408,15 +409,15 @@ class SparkOnK8S(LoggingMixin):
             basic_conf.update(self._executor_annotations(annotations=executor_annotations))
         # Handle executor template (either string content or local file path)
         executor_template_configmap = None
-        if executor_template and executor_pod_template_path:
+        if executor_pod_template and executor_pod_template_path:
             raise ValueError(
                 "Both executor_template and executor_pod_template_path are provided. "
                 "Please provide only one of them."
             )
 
-        if executor_template:
+        if executor_pod_template:
             # Process the template (read from file if it's a path, otherwise use as content)
-            template_content = self._process_executor_template(executor_template)
+            template_content = self._process_executor_template(executor_pod_template)
             
             # Create a ConfigMap for the executor template
             executor_template_configmap = {

--- a/spark_on_k8s/client.py
+++ b/spark_on_k8s/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import re
 import yaml
 from dataclasses import dataclass

--- a/spark_on_k8s/utils/configuration.py
+++ b/spark_on_k8s/utils/configuration.py
@@ -78,6 +78,7 @@ class Configuration:
         getenv("SPARK_ON_K8S_SPARK_EXECUTOR_ANNOTATIONS", "{}")
     )
     SPARK_ON_K8S_EXECUTOR_POD_TEMPLATE_PATH = getenv("SPARK_ON_K8S_EXECUTOR_POD_TEMPLATE_PATH", None)
+    SPARK_ON_K8S_EXECUTOR_TEMPLATE = getenv("SPARK_ON_K8S_EXECUTOR_TEMPLATE", None)
     try:
         from kubernetes_asyncio import client as async_k8s
 

--- a/tests/test_spark_client.py
+++ b/tests/test_spark_client.py
@@ -1015,7 +1015,7 @@ spec:
             app_name="pyspark-job-example",
             app_arguments=["100000"],
             app_waiter="no_wait",
-            executor_template=template_content,
+            executor_pod_template=template_content,
         )
 
         # Check that ConfigMap was created
@@ -1071,7 +1071,7 @@ spec:
             app_name="pyspark-job-example",
             app_arguments=["100000"],
             app_waiter="no_wait",
-            executor_template="./executor-template.yaml",
+            executor_pod_template="./executor-template.yaml",
         )
 
         # Check that ConfigMap was created

--- a/tests/test_spark_client.py
+++ b/tests/test_spark_client.py
@@ -1021,7 +1021,7 @@ spec:
         # Check that ConfigMap was created
         assert mock_create_namespaced_config_map.called
         created_configmap = mock_create_namespaced_config_map.call_args[1]["body"]
-        assert created_configmap.metadata.name == "pyspark-job-example-20240114225118-executor-template"
+        assert created_configmap.metadata.name == "pyspark-job-example-20240114121231-executor-template"
         assert "executor-template.yaml" in created_configmap.data
         assert template_content.strip() in created_configmap.data["executor-template.yaml"]
 
@@ -1033,16 +1033,16 @@ spec:
             for conf in arguments
             if conf.startswith("spark.kubernetes.executor")
         }
-        assert executor_config.get("spark.kubernetes.executor.podTemplateFile") == "/opt/spark/conf/executor-template.yaml"
+        assert executor_config.get("spark.kubernetes.executor.podTemplateFile") == "/opt/spark/executor-template/executor-template.yaml"
 
         # Check that volume and volume mount were created
         volumes = created_pod.spec.volumes
         volume_names = [v.name for v in volumes]
-        assert "pyspark-job-example-20240114225118-executor-template" in volume_names
+        assert "pyspark-job-example-20240114121231-executor-template" in volume_names
 
         driver_volume_mounts = created_pod.spec.containers[0].volume_mounts
         driver_mount_names = [vm.name for vm in driver_volume_mounts] if driver_volume_mounts else []
-        assert "pyspark-job-example-20240114225118-executor-template" in driver_mount_names
+        assert "pyspark-job-example-20240114121231-executor-template" in driver_mount_names
 
     @mock.patch("spark_on_k8s.k8s.sync_client.KubernetesClientManager.create_client")
     @mock.patch("kubernetes.client.api.core_v1_api.CoreV1Api.create_namespaced_pod")
@@ -1076,7 +1076,7 @@ spec:
         # Check that ConfigMap was created
         assert mock_create_namespaced_config_map.called
         created_configmap = mock_create_namespaced_config_map.call_args[1]["body"]
-        assert created_configmap.metadata.name == "pyspark-job-example-20240114225118-executor-template"
+        assert created_configmap.metadata.name == "pyspark-job-example-20240114121231-executor-template"
         assert "executor-template.yaml" in created_configmap.data
 
         # Check that pod was created with correct Spark configuration
@@ -1087,7 +1087,7 @@ spec:
             for conf in arguments
             if conf.startswith("spark.kubernetes.executor")
         }
-        assert executor_config.get("spark.kubernetes.executor.podTemplateFile") == "/opt/spark/conf/executor-template.yaml"
+        assert executor_config.get("spark.kubernetes.executor.podTemplateFile") == "/opt/spark/executor-template/executor-template.yaml"
 
     @pytest.mark.parametrize(
         "app_waiter",


### PR DESCRIPTION
This aims at simplifying the executor template management by letting the user to just pass the yaml content for the executor template and let the lib manage a configmap and manage it's lifecycle

The pr :
- adds some example documentation
- adds some tests
- keep backward compatibility with the previous `executor_pod_template_path`
- has been tested with success on k8s


Let me know 